### PR TITLE
Refresh display between user selected demos

### DIFF
--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -113,9 +113,10 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
                 next(runner)
                 next(frame_tick)
 
-            # Stop demo and remove everything from the previous demo
+            logger.info("Stopping current demo and get ready for next one...")
             demo.stop()
             screen.clear()
+            screen.refresh()
             while not demo_input_queue.empty():
                 demo_input_queue.get()
 


### PR DESCRIPTION
Previously, the display got refreshed (remove artifacts) between random demos, but not when the user was picking demos. This PR adds refreshing between demos even when the user selects a demo. This fixes #6.

This change needs to be tested on hardware to ensure that the amount of latency introduced by refreshing the screen is not noticeable.