### PR TITLE
Add verbose flag to CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,24 @@
-import click
+import sys
 
-from runners import kiosk, demo, test, utils
+import click
+from loguru import logger
+
+from runners import demo, kiosk, test, utils
+
+logger_level = ["ERROR", "WARNING", "SUCCESS", "INFO", "DEBUG", "TRACE"]
 
 
 @click.group()
-def cli():
+@click.option("-v", "--verbose", count=True)
+def cli(verbose):
     """CLI group."""
+
+    if verbose >= len(logger_level):
+        print(f"Only {len(logger_level) - 1} verbose flags allowed.")
+        exit()
+
+    logger.remove()  # Remove default logger
+    logger.add(sys.stderr, level=logger_level[verbose])  # Add new logger back
 
 
 @cli.command(name="simulator")


### PR DESCRIPTION
I added a verbose flag to the CLI. This fixes #11. It needs to be used before the subcommand. For example:

```
python main.py -v demo snake
```

It won't work if the `-v` is after the word `demo` because it becomes a subcommand option. You can add multiple flags to increase the verbosity. Here is the mapping of flags to log level:

| Flag     | Log Level                                |
|----------|------------------------------------------|
| None     | `logger.critical()` and `logger.error()` |
| `-v`     | `logger.warning()`                       |
| `-vv`    | `logger.success()`                       |
| `-vvv`   | `logger.info()`                          |
| `-vvvv`  | `logger.debug()`                         |
| `-vvvvv` | `logger.trace()`                         |

I didn't know about the `logger.success()` call so I've never used that before. We might want to refactor some of our code to use the "right" logging level.

Let me know if you want me to change something. Having 5 `-v`'s seems like a lot so maybe we want to combine some of these states together. I feel like I'm used to seeing at most 3 `-v`'s (`-vvv`), but I don't think there are any conventions.