### PR TITLE
Update testing framework and code to support Python 3.10 to Python 3.13

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -21,16 +21,26 @@ jobs:
           default: "${{ matrix.python-version }}"
           command: pip install -U pip  # upgrade pip after installing python
 
-      - name: Set up environment
+      - name: Set up Python version
         run: |
-          rm -rf /tmp/test
-          mkdir /tmp/test
-          pwd
+          eval "$(pyenv init --path)"
           python -V
           python3 -V
-          pyenv local ${{ matrix.python-version }}
+          pyenv ${{ matrix.python-version }}
           python -V
           python3 -V
+
+      # - name: Set up environment
+      #   run: |
+      #     rm -rf /tmp/test-${{ matrix.python-version }}
+      #     mkdir /tmp/test-${{ matrix.python-version }}
+      #     pwd
+      #     python -V
+      #     python3 -V
+      #     pyenv local ${{ matrix.python-version }}
+      #     python -V
+      #     python3 -V
+      #     rm -rf /tmp/test-${{ matrix.python-version }}
 
           
       #     python -V

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -10,7 +10,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get install libatlas-base-dev python3-pip python3-venv
+          sudo apt-get install -y libatlas-base-dev python3-pip python3-venv
 
       - name: Set up environment
         run: |

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        python-version: ["3.10.14"]
+        python-version: ["3.10", "3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -43,9 +43,7 @@ jobs:
           export PATH="$PYENV_ROOT/bin:$PATH"
           eval "$(pyenv init --path)"
           pyenv local ${{ matrix.python-version }}
-          python -V
           python -m venv /tmp/test-${{ matrix.python-version }}/.venv
-          /tmp/test-${{ matrix.python-version }}/.venv/bin/python -V
           
       - name: Install project dependencies
         run: |

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -5,30 +5,41 @@ on: [push]
 jobs:
   build:
     runs-on: self-hosted
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install system dependencies
         run: |
           sudo apt-get install -y libatlas-base-dev python3-pip python3-venv
+
+      - name: Install python version
+        uses: gabrielfalcao/pyenv-action@v18
+        with:
+          default: "${{ matrix.python-version }}"
+          command: pip install -U pip  # upgrade pip after installing python
 
       - name: Set up environment
         run: |
           rm -rf /tmp/test
           mkdir /tmp/test
           python -V
-          python3 -V
-          python -m venv /tmp/test/.venv
+          
+      #     python -V
+      #     python3 -V
+      #     python -m venv /tmp/test/.venv
 
-      - name: Install project dependencies
-        run: |
-          /tmp/test/.venv/bin/python -m pip install -r requirements.txt
+      # - name: Install project dependencies
+      #   run: |
+      #     /tmp/test/.venv/bin/python -m pip install -r requirements.txt
 
-      - name: Run all demos to make sure they load
-        run: |
-          /tmp/test/.venv/bin/python main.py test
+      # - name: Run all demos to make sure they load
+      #   run: |
+      #     /tmp/test/.venv/bin/python main.py test
 
-      - name: Clean up code
-        if: always()
-        run: |
-          rm -rf /tmp/test
+      # - name: Clean up code
+      #   if: always()
+      #   run: |
+      #     rm -rf /tmp/test

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -16,6 +16,9 @@ jobs:
         run: |
           rm -rf /tmp/test
           mkdir /tmp/test
+          which -a python
+          which -a python3
+          pyenv local 3.10.14
           python -m venv /tmp/test/.venv
 
       - name: Install project dependencies

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -25,7 +25,11 @@ jobs:
         run: |
           rm -rf /tmp/test
           mkdir /tmp/test
+          pwd
+          which -a python
+          which -a python3
           python -V
+          python3 -V
           
       #     python -V
       #     python3 -V

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -15,12 +15,6 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y libatlas-base-dev python3-pip python3-venv python3-dev libffi-dev build-essential libgl1-mesa-glx libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libjpeg-dev libpng-dev libfreetype6-dev libportmidi-dev
 
-      - name: Install python version
-        uses: gabrielfalcao/pyenv-action@v18
-        with:
-          default: "${{ matrix.python-version }}"
-          command: pip install -U pip  # upgrade pip after installing python
-
       - name: Set up Python version
         run: |
           eval "$(pyenv init --path)"

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -23,7 +23,7 @@ jobs:
           eval "$(pyenv init --path)"
           python -V
           python3 -V
-          pyenv ${{ matrix.python-version }}
+          pyenv shell ${{ matrix.python-version }}
           python -V
           python3 -V
 

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10.14"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -26,10 +26,12 @@ jobs:
           rm -rf /tmp/test
           mkdir /tmp/test
           pwd
-          which -a python
-          which -a python3
           python -V
           python3 -V
+          pyenv local ${{ matrix.python-version }}
+          python -V
+          python3 -V
+
           
       #     python -V
       #     python3 -V

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -13,7 +13,22 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt update && sudo apt install -y libatlas-base-dev python3-pip python3-venv python3-dev libffi-dev build-essential libgl1-mesa-glx libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libjpeg-dev libpng-dev libfreetype6-dev libportmidi-dev
+          sudo apt update
+          sudo apt install -y libatlas-base-dev \
+                              python3-pip \
+                              python3-venv \
+                              python3-dev \
+                              libffi-dev \
+                              build-essential \
+                              libgl1-mesa-glx \
+                              libsdl2-dev \
+                              libsdl2-image-dev \
+                              libsdl2-mixer-dev \
+                              libsdl2-ttf-dev \
+                              libjpeg-dev \
+                              libpng-dev \
+                              libfreetype6-dev \
+                              libportmidi-dev \
 
       - name: Set up folder
         run: |
@@ -24,6 +39,9 @@ jobs:
 
       - name: Set up Python version and virtual environment
         run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           pyenv local ${{ matrix.python-version }}
           python -V
           python -m venv /tmp/test-${{ matrix.python-version }}/.venv

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -17,6 +17,9 @@ jobs:
 
       - name: Set up Python version
         run: |
+          echo $HOME
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
           eval "$(pyenv init --path)"
           python -V
           python3 -V

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -16,9 +16,8 @@ jobs:
         run: |
           rm -rf /tmp/test
           mkdir /tmp/test
-          which -a python
-          which -a python3
-          pyenv local 3.10.14
+          python -V
+          python3 -V
           python -m venv /tmp/test/.venv
 
       - name: Install project dependencies

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -23,7 +23,7 @@ jobs:
           eval "$(pyenv init --path)"
           python -V
           python3 -V
-          pyenv shell ${{ matrix.python-version }}
+          pyenv local ${{ matrix.python-version }}
           python -V
           python3 -V
 

--- a/.github/workflows/raspberry_pi.yml
+++ b/.github/workflows/raspberry_pi.yml
@@ -15,44 +15,29 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y libatlas-base-dev python3-pip python3-venv python3-dev libffi-dev build-essential libgl1-mesa-glx libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libjpeg-dev libpng-dev libfreetype6-dev libportmidi-dev
 
-      - name: Set up Python version
+      - name: Set up folder
         run: |
-          echo $HOME
-          export PYENV_ROOT="$HOME/.pyenv"
-          export PATH="$PYENV_ROOT/bin:$PATH"
-          eval "$(pyenv init --path)"
-          python -V
-          python3 -V
+          pwd
+          rm -rf /tmp/test-${{ matrix.python-version }}
+          mkdir /tmp/test-${{ matrix.python-version }}
+          cd /tmp/test-${{ matrix.python-version }}
+
+      - name: Set up Python version and virtual environment
+        run: |
           pyenv local ${{ matrix.python-version }}
           python -V
-          python3 -V
-
-      # - name: Set up environment
-      #   run: |
-      #     rm -rf /tmp/test-${{ matrix.python-version }}
-      #     mkdir /tmp/test-${{ matrix.python-version }}
-      #     pwd
-      #     python -V
-      #     python3 -V
-      #     pyenv local ${{ matrix.python-version }}
-      #     python -V
-      #     python3 -V
-      #     rm -rf /tmp/test-${{ matrix.python-version }}
-
+          python -m venv /tmp/test-${{ matrix.python-version }}/.venv
+          /tmp/test-${{ matrix.python-version }}/.venv/bin/python -V
           
-      #     python -V
-      #     python3 -V
-      #     python -m venv /tmp/test/.venv
+      - name: Install project dependencies
+        run: |
+          /tmp/test-${{ matrix.python-version }}/.venv/bin/python -m pip install -r requirements.txt
 
-      # - name: Install project dependencies
-      #   run: |
-      #     /tmp/test/.venv/bin/python -m pip install -r requirements.txt
+      - name: Run all demos to make sure they load
+        run: |
+          /tmp/test-${{ matrix.python-version }}/.venv/bin/python main.py test
 
-      # - name: Run all demos to make sure they load
-      #   run: |
-      #     /tmp/test/.venv/bin/python main.py test
-
-      # - name: Clean up code
-      #   if: always()
-      #   run: |
-      #     rm -rf /tmp/test
+      - name: Clean up code
+        if: always()
+        run: |
+          rm -rf /tmp/test-${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 black==24.3.0
 click==8.1.3
 inputs==0.5
-loguru==0.6.0
-numpy==1.23.0
+loguru==0.7.2
+numpy==2.1.2
 opencv-python==4.6.0.66
 paho-mqtt==1.6.1
 perlin-noise==1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==8.1.3
 inputs==0.5
 loguru==0.7.2
 numpy==2.1.2
-opencv-python==4.10
+opencv-python==4.10.0.84
 paho-mqtt==1.6.1
 perlin-noise==1.12
 pygame

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==8.1.3
 inputs==0.5
 loguru==0.7.2
 numpy==2.1.2
-opencv-python==4.6.0.66
+opencv-python==4.10
 paho-mqtt==1.6.1
 perlin-noise==1.12
 pygame

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ paho-mqtt==1.6.1
 perlin-noise==1.12
 pygame
 pygame-widgets==1.0.0
-PyYAML==6.0
+PyYAML==6.0.2
 spidev==3.5
 urllib3==1.26.19
 sysv-ipc==1.1.0


### PR DESCRIPTION
Fixes #60. All tests work with Python 3.13. We will need to prepare the Pi that the SSS is running on to install Python 3.13 before we pull in this change. It is currently running Python 3.7

Changes:

- Updated local tester to test different versions of Python
- Bumped library versions to support newer versions of Python
- Removed support for Python 3.9 and below