### PR TITLE
Fix the order of the demos when printed out

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,9 @@ def run_kiosk(simulate, testing):
 @cli.command("demo")
 @click.argument(
     "name",
-    type=click.Choice([name for name, _ in utils.get_demos()], case_sensitive=False),
+    type=click.Choice(
+        sorted([name for name, _ in utils.get_demos()]), case_sensitive=False
+    ),
 )
 @click.option(
     "-s",


### PR DESCRIPTION
When you run `python main.py -vvvv demo`, the order of the demos seems random. Now they are in order.