### PR TITLE
Create Menu System

### DIFF
--- a/controllers/gamepad.py
+++ b/controllers/gamepad.py
@@ -98,9 +98,9 @@ def start_processing_input(system_queue, demo_input_queue):
                         demo_input_queue.put("START_R")
                 elif event.code == "BTN_BASE3":
                     if event.state:
-                        demo_input_queue.put("SEL_P")
+                        system_queue.put("SEL_P")
                     else:
-                        demo_input_queue.put("SEL_R")
+                        system_queue.put("SEL_R")
                 elif event.code == "BTN_THUMB":
                     if event.state:
                         demo_input_queue.put("PRI_P")

--- a/controllers/keyboard.py
+++ b/controllers/keyboard.py
@@ -5,9 +5,11 @@ from pygame.locals import (
     K_DOWN,
     K_ESCAPE,
     K_LEFT,
+    K_LMETA,
     K_RCTRL,
     K_RETURN,
     K_RIGHT,
+    K_RMETA,
     K_SPACE,
     K_UP,
     KEYDOWN,
@@ -63,7 +65,7 @@ def start_processing_input(system_queue, demo_input_queue):
                     demo_input_queue.put("PRI_P")
                 elif event.key == K_n:
                     system_queue.put("SEC_P")
-                elif event.key == K_RCTRL:
+                elif event.key in [K_RCTRL, K_RMETA, K_LMETA]:
                     system_queue.put("SEL_P")
 
             # check for KEYUP event and pass into input queue
@@ -82,7 +84,7 @@ def start_processing_input(system_queue, demo_input_queue):
                     demo_input_queue.put("PRI_R")
                 elif event.key == K_n:
                     system_queue.put("SEC_R")
-                elif event.key == K_RCTRL:
+                elif event.key in [K_RCTRL, K_RMETA, K_LMETA]:
                     system_queue.put("SEL_R")
 
             # Check for QUIT event.

--- a/controllers/keyboard.py
+++ b/controllers/keyboard.py
@@ -66,7 +66,7 @@ def start_processing_input(system_queue, demo_input_queue):
                 elif event.key == K_n:
                     system_queue.put("SEC_P")
                 elif event.key in [K_RCTRL, K_RMETA, K_LMETA]:
-                    system_queue.put("SEL_P")
+                    system_queue.put("SEL")
 
             # check for KEYUP event and pass into input queue
             elif event.type == KEYUP:
@@ -84,15 +84,6 @@ def start_processing_input(system_queue, demo_input_queue):
                     demo_input_queue.put("PRI_R")
                 elif event.key == K_n:
                     system_queue.put("SEC_R")
-
-                # Note: this has purposely been removed. I argue that we don't
-                # need to know when *this* key has been released. I would like
-                # to use it only for system queue stuff and not for game input
-                # in which case, I don't think anything cares about when it got
-                # pressed vs when it got released. It just makes processing the
-                # key stroke harder because there is two events.
-                # elif event.key in [K_RCTRL, K_RMETA, K_LMETA]:
-                #     system_queue.put("SEL_R")
 
             # Check for QUIT event.
             elif event.type == QUIT:

--- a/controllers/keyboard.py
+++ b/controllers/keyboard.py
@@ -62,9 +62,9 @@ def start_processing_input(system_queue, demo_input_queue):
                 elif event.key == K_SPACE:
                     demo_input_queue.put("PRI_P")
                 elif event.key == K_n:
-                    demo_input_queue.put("SEC_P")
+                    system_queue.put("SEC_P")
                 elif event.key == K_RCTRL:
-                    demo_input_queue.put("SEL_P")
+                    system_queue.put("SEL_P")
 
             # check for KEYUP event and pass into input queue
             elif event.type == KEYUP:
@@ -81,9 +81,9 @@ def start_processing_input(system_queue, demo_input_queue):
                 elif event.key == K_SPACE:
                     demo_input_queue.put("PRI_R")
                 elif event.key == K_n:
-                    demo_input_queue.put("SEC_R")
+                    system_queue.put("SEC_R")
                 elif event.key == K_RCTRL:
-                    demo_input_queue.put("SEL_R")
+                    system_queue.put("SEL_R")
 
             # Check for QUIT event.
             elif event.type == QUIT:

--- a/controllers/keyboard.py
+++ b/controllers/keyboard.py
@@ -84,8 +84,15 @@ def start_processing_input(system_queue, demo_input_queue):
                     demo_input_queue.put("PRI_R")
                 elif event.key == K_n:
                     system_queue.put("SEC_R")
-                elif event.key in [K_RCTRL, K_RMETA, K_LMETA]:
-                    system_queue.put("SEL_R")
+
+                # Note: this has purposely been removed. I argue that we don't
+                # need to know when *this* key has been released. I would like
+                # to use it only for system queue stuff and not for game input
+                # in which case, I don't think anything cares about when it got
+                # pressed vs when it got released. It just makes processing the
+                # key stroke harder because there is two events.
+                # elif event.key in [K_RCTRL, K_RMETA, K_LMETA]:
+                #     system_queue.put("SEL_R")
 
             # Check for QUIT event.
             elif event.type == QUIT:

--- a/controllers/keyboard.py
+++ b/controllers/keyboard.py
@@ -64,7 +64,7 @@ def start_processing_input(system_queue, demo_input_queue):
                 elif event.key == K_SPACE:
                     demo_input_queue.put("PRI_P")
                 elif event.key == K_n:
-                    system_queue.put("SEC_P")
+                    demo_input_queue.put("SEC_P")
                 elif event.key in [K_RCTRL, K_RMETA, K_LMETA]:
                     system_queue.put("SEL")
 
@@ -83,7 +83,7 @@ def start_processing_input(system_queue, demo_input_queue):
                 elif event.key == K_SPACE:
                     demo_input_queue.put("PRI_R")
                 elif event.key == K_n:
-                    system_queue.put("SEC_R")
+                    demo_input_queue.put("SEC_R")
 
             # Check for QUIT event.
             elif event.type == QUIT:

--- a/demos/breakout_ai/main.py
+++ b/demos/breakout_ai/main.py
@@ -79,11 +79,6 @@ class BreakoutAi:
 
         while True:
             while not gameover:
-                if not self.input_queue.empty():
-                    input_ = self.input_queue.get(block=False)
-                else:
-                    input_ = ""
-
                 if self.ball[1] <= self.level + 2:
                     row = self.ball[1]
                     if row in self.bricks.keys():

--- a/demos/menu/main.py
+++ b/demos/menu/main.py
@@ -1,6 +1,7 @@
 from loguru import logger
 
 from demos.utils import get_all_from_queue
+from runners.utils import get_demos
 
 
 class Menu:
@@ -13,9 +14,7 @@ class Menu:
     # User input is passed through input_queue
     # Game output is passed through output_queue
     # Screen updates are done through the screen object
-    def __init__(
-        self, input_queue, output_queue, screen, system_input_queue=None, demos=None
-    ):
+    def __init__(self, input_queue, output_queue, screen, system_input_queue=None):
         """
         Constructor
 
@@ -36,9 +35,8 @@ class Menu:
         # init demo/game specific variables here
         self.system_input_queue = system_input_queue
 
-        self.demos = demos or {}
         # Pull out the name of each demo
-        self.demos = [demo for demo in self.demos.keys()]
+        self.demos = [name for name, _ in get_demos()]
         # Fix up names
         self.demo_names = [demo.replace("_", " ") for demo in self.demos]
         # Truncate list of demos

--- a/demos/menu/main.py
+++ b/demos/menu/main.py
@@ -35,12 +35,12 @@ class Menu:
 
         # init demo/game specific variables here
         self.system_input_queue = system_input_queue
-        self.demos = demos or {}
 
+        self.demos = demos or {}
         # Pull out the name of each demo
-        self.demo_names = [demo for demo in self.demos.keys()]
+        self.demos = [demo for demo in self.demos.keys()]
         # Fix up names
-        self.demo_names = [demo.replace("_", " ") for demo in self.demo_names]
+        self.demo_names = [demo.replace("_", " ") for demo in self.demos]
         # Truncate list of demos
         self.demo_names = self.demo_names[
             : self.max_demos_per_column * self.num_columns
@@ -104,10 +104,10 @@ class Menu:
                     # If the user presses the select button
                     elif keypress == "SEL_P":
                         # Stop the menu demo
-                        self.system_input_queue.put(None)
+                        self.system_input_queue.put("QUIT")
                     elif keypress == "PRI_P":
                         # Start the selected demo
-                        self.system_input_queue.put(self.demo_names[selected])
+                        self.system_input_queue.put(self.demos[selected])
 
                 # Roll around the selected demo
                 selected %= len(self.demo_names)

--- a/demos/menu/main.py
+++ b/demos/menu/main.py
@@ -104,7 +104,7 @@ class Menu:
                         selected -= 1
                     elif keypress == "DOWN_P":
                         selected += 1
-                    elif keypress == "START_P":
+                    elif keypress == "START_P" and self.system_input_queue:
                         # Start the selected demo
                         self.system_input_queue.put(self.demos[selected])
 

--- a/demos/menu/main.py
+++ b/demos/menu/main.py
@@ -97,7 +97,7 @@ class Menu:
 
         while True:
             if not self.input_queue.empty():
-                # Check to see if there are any keypresses to read
+                # Check to see if there are any key presses to read
                 for keypress in get_all_from_queue(self.input_queue):
                     # If there are directional buttons pressed
                     if keypress == "UP_P":

--- a/demos/menu/main.py
+++ b/demos/menu/main.py
@@ -101,11 +101,7 @@ class Menu:
                         selected -= 1
                     elif keypress == "DOWN_P":
                         selected += 1
-                    # If the user presses the select button
-                    elif keypress == "SEL_P":
-                        # Stop the menu demo
-                        self.system_input_queue.put("QUIT")
-                    elif keypress == "PRI_P":
+                    elif keypress == "START_P":
                         # Start the selected demo
                         self.system_input_queue.put(self.demos[selected])
 

--- a/demos/menu/main.py
+++ b/demos/menu/main.py
@@ -47,6 +47,7 @@ class Menu:
         ]
 
         self.flash_rate = 5
+        self.title = "DEMOS"
 
     def _draw_menu(self):
         # Draw the list of demos
@@ -86,7 +87,9 @@ class Menu:
         count = 0
 
         # Set up initial screen
-        self.screen.draw_text(self.screen.x_width // 2, 0, "DEMOS")
+        self.screen.draw_text(
+            (self.screen.x_width - len(self.title)) // 2, 0, self.title
+        )
         self.screen.draw_hline(0, 2, self.screen.x_width)
         self._draw_menu()
         self._update_menu(old_selected, selected)

--- a/demos/menu/main.py
+++ b/demos/menu/main.py
@@ -1,0 +1,134 @@
+from loguru import logger
+
+from demos.utils import get_all_from_queue
+
+
+class Menu:
+    """This demo displays a menu with all of the available demos"""
+
+    demo_time = None
+    max_demos_per_column = 15
+    num_columns = 2
+
+    # User input is passed through input_queue
+    # Game output is passed through output_queue
+    # Screen updates are done through the screen object
+    def __init__(
+        self, input_queue, output_queue, screen, system_input_queue=None, demos=None
+    ):
+        """
+        Constructor
+
+        Args:
+            input_queue (Queue): The input queue
+            output_queue (Queue): The output queue
+            screen (Screen): The screen to draw on
+            demos (list): List of all available demos
+
+        """
+        # Provide the framerate in frames/seconds and the amount of time of the demo in seconds
+        self.frame_rate = 20
+
+        self.input_queue = input_queue
+        self.output_queue = output_queue
+        self.screen = screen
+
+        # init demo/game specific variables here
+        self.system_input_queue = system_input_queue
+        self.demos = demos or {}
+
+        # Pull out the name of each demo
+        self.demo_names = [demo for demo in self.demos.keys()]
+        # Fix up names
+        self.demo_names = [demo.replace("_", " ") for demo in self.demo_names]
+        # Truncate list of demos
+        self.demo_names = self.demo_names[
+            : self.max_demos_per_column * self.num_columns
+        ]
+
+        self.flash_rate = 5
+
+    def _draw_menu(self):
+        # Draw the list of demos
+        for i, demo in enumerate(self.demo_names):
+            if i < self.max_demos_per_column:
+                self.screen.draw_text(0, 4 + (i * 2), f"{i + 1:2}. {demo.upper()}")
+
+            if i >= self.max_demos_per_column:
+                self.screen.draw_text(
+                    self.screen.x_width // 2,
+                    4 + ((i - self.max_demos_per_column) * 2),
+                    f"{i + 1:2}. {demo.upper()}",
+                )
+
+    def _update_menu(self, selected, show_text=True):
+        if selected >= self.max_demos_per_column:
+            selected_v_offset = selected - self.max_demos_per_column
+            selected_h_offset = self.screen.x_width // 2
+        else:
+            selected_v_offset = selected
+            selected_h_offset = 0
+
+        if show_text:
+            text = f"{selected + 1:2}. {self.demo_names[selected].upper()}"
+        else:
+            text = f"{selected + 1:2}. {' ' * len(self.demo_names[selected])}"
+
+        self.screen.draw_text(selected_h_offset, 4 + (selected_v_offset * 2), text)
+
+    def run(self):
+        """Runs the simulation loop"""
+        logger.info("Running the menu demo")
+
+        selected = 0
+        old_selected = 0
+        show_text = True
+        count = 0
+
+        # Set up initial screen
+        self.screen.draw_text(self.screen.x_width // 2, 0, "DEMOS")
+        self.screen.draw_hline(0, 2, self.screen.x_width)
+        self._draw_menu()
+        self._update_menu(old_selected, selected)
+        self.screen.push()
+
+        while True:
+            if not self.input_queue.empty():
+                # Check to see if there are any keypresses to read
+                for keypress in get_all_from_queue(self.input_queue):
+                    # If there are directional buttons pressed
+                    if keypress == "UP_P":
+                        selected -= 1
+                    elif keypress == "DOWN_P":
+                        selected += 1
+                    # If the user presses the select button
+                    elif keypress == "SEL_P":
+                        # Stop the menu demo
+                        self.system_input_queue.put(None)
+                    elif keypress == "PRI_P":
+                        # Start the selected demo
+                        self.system_input_queue.put(self.demo_names[selected])
+
+                # Roll around the selected demo
+                selected %= len(self.demo_names)
+
+            if selected != old_selected:
+                # The selected item changed, so redraw the menu
+                # self._update_menu(old_selected, selected)
+                self._update_menu(old_selected, show_text=True)
+                self._update_menu(selected, show_text=False)
+
+            if count == self.flash_rate:
+                self._update_menu(selected, show_text=show_text)
+                show_text = not show_text
+                count = 0
+
+            self.screen.push()
+            old_selected = selected
+            count += 1
+
+            yield
+
+    def stop(self):
+        """Reset the state of the demo if needed, else leave blank"""
+        pass

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -186,9 +186,8 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
                 if queues.system_queue.queue[0] == "SEL_P":
                     logger.info("Select was pressed—bring up menu")
 
-                    # Capture that item from the queue
-                    queues.system_queue.get() # Captures SEL_P
-                    queues.system_queue.get() # Captures SEL_R
+                    queues.system_queue.get()  # Captures SEL_P
+                    queues.system_queue.get()  # Captures SEL_R
 
                     current_demo = demos["menu"](
                         queues.demo_input_queue,

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -170,12 +170,6 @@ def play_demo_from_idle(demo, handle_input, queues, screen, demo_time_override):
             screen.clear()
             break
 
-        if not queues.demo_input_queue.empty():
-            logger.info("Demo input has been received on demo queue. Exiting demo...")
-            demo.stop()
-            screen.clear()
-            break
-
         try:
             # TODO: Should there also be handle output?
             next(handle_input)
@@ -226,37 +220,33 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
             if not queues.system_queue.empty():
                 logger.info("Got input from the system...")
 
-                demo_cls = get_demo_from_user(queues.system_queue, demos)
-                if demo_cls is None:
-                    continue
-                current_demo = demo_cls(
-                    queues.demo_input_queue, queues.demo_output_queue, screen.display
-                )
+                if queues.system_queue.queue[0] == "SEC_P":
+                    logger.info("Select was pressed—bring up menu")
+
+                    # Capture that item from the queue
+                    queues.system_queue.get()
+
+                    current_demo = demos["menu"](
+                        queues.demo_input_queue,
+                        queues.demo_output_queue,
+                        screen.display,
+                        system_input_queue=queues.system_queue,
+                        demos=demos,
+                    )
+
+                else:
+                    demo_cls = get_demo_from_user(queues.system_queue, demos)
+                    if demo_cls is None:
+                        continue
+
+                    current_demo = demo_cls(
+                        queues.demo_input_queue,
+                        queues.demo_output_queue,
+                        screen.display,
+                    )
 
                 play_demo_from_user(
                     current_demo,
-                    handle_input,
-                    queues,
-                    screen,
-                    user_input_timeout,
-                )
-
-            elif not queues.demo_input_queue.empty():
-                logger.info("Got input from the user...")
-
-                # Clear out the queue so that no input gets passed to the demo
-                queues.demo_input_queue.queue.clear()
-
-                menu_demo = demos["menu"](
-                    queues.demo_input_queue,
-                    queues.demo_output_queue,
-                    screen.display,
-                    system_input_queue=queues.system_queue,
-                    demos=demos,
-                )
-
-                play_demo_from_user(
-                    menu_demo,
                     handle_input,
                     queues,
                     screen,

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -183,11 +183,12 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
             if not queues.system_queue.empty():
                 logger.info("Got input from the system...")
 
-                if queues.system_queue.queue[0] == "SEL":
+                if queues.system_queue.queue[0] == "SEL_P":
                     logger.info("Select was pressed—bring up menu")
 
                     # Capture that item from the queue
-                    queues.system_queue.get()
+                    queues.system_queue.get() # Captures SEL_P
+                    queues.system_queue.get() # Captures SEL_R
 
                     current_demo = demos["menu"](
                         queues.demo_input_queue,

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -1,7 +1,6 @@
 import random
 import sys
 import time
-from importlib import import_module
 from queue import Empty
 
 from loguru import logger
@@ -9,42 +8,6 @@ from loguru import logger
 import broadcasters
 import controllers
 from runners import utils
-
-
-def load_demo(module_name):
-    """
-    Given a module name it will load the module and get the modules demo
-    class.
-
-    Args:
-        module_name (str): Name of the module to load.
-
-    Returns:
-        class: The demo class.
-    """
-    logger.debug(f"Loading {module_name}")
-    return utils.get_demo_cls(import_module(module_name))
-
-
-def load_demos(demo_dir="demos"):
-    """
-    Loads all demos for a given directory. It returns the demos in a dictionary
-    with the name of the demo as key and the demo module as the value.
-
-    Args:
-        demo_dir (str): Directory where the demos are located.
-
-    Returns:
-        dict: Dictionary with the name of the demo as key and the demo module
-    """
-    logger.debug("Loading demos...")
-
-    demos = utils.get_demos(demo_dir)
-
-    # Load the module
-    demos = {name: load_demo(module) for name, module in demos}
-
-    return demos
 
 
 def get_random_demo(demos):
@@ -202,7 +165,7 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
 
     queues = utils.Queues()
 
-    demos = load_demos()
+    demos = utils.load_demos()
     random_demos = get_random_demo(demos)
     handle_input = controllers.start_inputs(
         queues.system_queue, queues.demo_input_queue

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -194,7 +194,6 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
                         queues.demo_output_queue,
                         screen.display,
                         system_input_queue=queues.system_queue,
-                        demos=demos,
                     )
 
                 else:

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -244,14 +244,14 @@ def run(simulate, testing=False):
 
     if simulate:
         from display.virtual_screen import (
-            VirtualScreen,
-        )  # pylint: disable=import-outside-toplevel
+            VirtualScreen,  # pylint: disable=import-outside-toplevel
+        )
 
         screen = VirtualScreen()
     else:
         from display.physical_screen import (
-            PhysicalScreen,
-        )  # pylint: disable=import-outside-toplevel
+            PhysicalScreen,  # pylint: disable=import-outside-toplevel
+        )
 
         screen = PhysicalScreen()
 

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -183,7 +183,7 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
             if not queues.system_queue.empty():
                 logger.info("Got input from the system...")
 
-                if queues.system_queue.queue[0] == "SEL_P":
+                if queues.system_queue.queue[0] == "SEL":
                     logger.info("Select was pressed—bring up menu")
 
                     # Capture that item from the queue

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -220,7 +220,7 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
             if not queues.system_queue.empty():
                 logger.info("Got input from the system...")
 
-                if queues.system_queue.queue[0] == "SEC_P":
+                if queues.system_queue.queue[0] == "SEL_P":
                     logger.info("Select was pressed—bring up menu")
 
                     # Capture that item from the queue

--- a/runners/kiosk.py
+++ b/runners/kiosk.py
@@ -128,6 +128,7 @@ def play_demo_from_user(
         if not queues.demo_input_queue.empty() and demo.demo_time is None:
             last_input_time = time.time()
 
+        # TODO: Should this also handle output?
         next(handle_input)
         next(runner)
         next(frame_tick)
@@ -164,12 +165,19 @@ def play_demo_from_idle(demo, handle_input, queues, screen, demo_time_override):
     while demo_time > (time.time() - start_time):
         # We have received input from the user, so we need to stop the demo
         if not queues.system_queue.empty():
-            logger.info("User input has been received. Exiting demo...")
+            logger.info("User input has been received on system queue. Exiting demo...")
+            demo.stop()
+            screen.clear()
+            break
+
+        if not queues.demo_input_queue.empty():
+            logger.info("Demo input has been received on demo queue. Exiting demo...")
             demo.stop()
             screen.clear()
             break
 
         try:
+            # TODO: Should there also be handle output?
             next(handle_input)
             next(runner)
             next(frame_tick)
@@ -206,17 +214,17 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
         queues.system_queue, queues.demo_input_queue
     )
     handle_output = broadcasters.start_outputs(
-        queues.system_queue, queues.demo_input_queue
+        queues.system_queue, queues.demo_output_queue
     )
     current_demo = None
 
     try:
         while True:
-            while not queues.system_queue.empty():
-                logger.info("Got input from the user...")
+            next(handle_input)
+            next(handle_output)
 
-                next(handle_input)
-                next(handle_output)
+            if not queues.system_queue.empty():
+                logger.info("Got input from the system...")
 
                 demo_cls = get_demo_from_user(queues.system_queue, demos)
                 if demo_cls is None:
@@ -233,7 +241,29 @@ def run_loop(screen, user_input_timeout=300, demo_time_override=None):
                     user_input_timeout,
                 )
 
-            while queues.system_queue.empty():
+            elif not queues.demo_input_queue.empty():
+                logger.info("Got input from the user...")
+
+                # Clear out the queue so that no input gets passed to the demo
+                queues.demo_input_queue.queue.clear()
+
+                menu_demo = demos["menu"](
+                    queues.demo_input_queue,
+                    queues.demo_output_queue,
+                    screen.display,
+                    system_input_queue=queues.system_queue,
+                    demos=demos,
+                )
+
+                play_demo_from_user(
+                    menu_demo,
+                    handle_input,
+                    queues,
+                    screen,
+                    user_input_timeout,
+                )
+
+            else:
                 logger.info("No input from user...")
 
                 current_demo = next(random_demos)(
@@ -261,15 +291,15 @@ def run(simulate, testing=False):
     """
 
     if simulate:
-        from display.virtual_screen import (  # pylint: disable=import-outside-toplevel
+        from display.virtual_screen import (
             VirtualScreen,
-        )
+        )  # pylint: disable=import-outside-toplevel
 
         screen = VirtualScreen()
     else:
-        from display.physical_screen import (  # pylint: disable=import-outside-toplevel
+        from display.physical_screen import (
             PhysicalScreen,
-        )
+        )  # pylint: disable=import-outside-toplevel
 
         screen = PhysicalScreen()
 

--- a/runners/utils.py
+++ b/runners/utils.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 from queue import Queue
+
+from loguru import logger
 
 
 @dataclass
@@ -53,3 +56,39 @@ def get_demo_cls(demo_module):
     return getattr(
         demo_module, "".join([word.capitalize() for word in demo_name.split("_")])
     )
+
+
+def load_demo(module_name):
+    """
+    Given a module name it will load the module and get the modules demo
+    class.
+
+    Args:
+        module_name (str): Name of the module to load.
+
+    Returns:
+        class: The demo class.
+    """
+    logger.debug(f"Loading {module_name}")
+    return get_demo_cls(import_module(module_name))
+
+
+def load_demos(demo_dir="demos"):
+    """
+    Loads all demos for a given directory. It returns the demos in a dictionary
+    with the name of the demo as key and the demo module as the value.
+
+    Args:
+        demo_dir (str): Directory where the demos are located.
+
+    Returns:
+        dict: Dictionary with the name of the demo as key and the demo module
+    """
+    logger.debug("Loading demos...")
+
+    demos = get_demos(demo_dir)
+
+    # Load the module
+    demos = {name: load_demo(module) for name, module in demos}
+
+    return demos


### PR DESCRIPTION
I think I developed a good solution to show the user a menu to pick a demo. Here is how it works:

- While in kiosk mode, if someone presses the select button (or ctrl on the keyboard), the menu comes up.
- The user selects a menu using the up and down arrows and presses the primary key ("A" button on the controller or enter on the keyboard) to start it.
- If users want to return to the menu, they press the select button again.

Now, on to how I implemented it:

- I created a new demo called menu. This menu demo is pretty much a regular demo, except it takes one extra argument that all other demos don't have: a reference to the input system queue.

- In the kiosk runner, if someone presses select, the current demo quits, and the menu demo gets called. That logic is handled in the kiosk runner code.

- When someone selects a menu item, the menu demo puts the name of the selected demo in the system queue. This is similar to how the web MQTT controller worked. It is quite elegant because it reuses the machinery that is already built into the SSS. However, it requires passing the input system queue into the demo, which is not ideal.


For this system to work, I had to change how select button presses are published. Previously, they were published on the demo queue. I propose in this PR that we publish it to the system queue. Essentially, we are giving the system access to one button that a demo won't have access to. I also removed the release event for the select button since a demo is not using it, and it is a pain to have to handle two events.

I also fixed a few bugs:

- Added command key for Macs (equal representation!)
- Change Breakout AI so it doesn't absorb input_queue items. There is no need since it is using AI.

More work could be done on making the menu demo better, but I think for now it is a good start.

Will you try it and give me some feedback? It is on the menu_system branch.

This fixes #70.
